### PR TITLE
match (lib)zmq.dll for windows

### DIFF
--- a/zmq.nim
+++ b/zmq.nim
@@ -57,7 +57,7 @@
 {.deadCodeElim: on.}
 when defined(windows):
   const
-    zmqdll* = "zmq.dll"
+    zmqdll* = "(lib)zmq.dll"
 elif defined(macosx):
   const
     zmqdll* = "libzmq.dylib"

--- a/zmq.nim
+++ b/zmq.nim
@@ -57,7 +57,7 @@
 {.deadCodeElim: on.}
 when defined(windows):
   const
-    zmqdll* = "(lib)zmq.dll"
+    zmqdll* = "(lib|)zmq.dll"
 elif defined(macosx):
   const
     zmqdll* = "libzmq.dylib"

--- a/zmq.nimble
+++ b/zmq.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.3.1"
+version       = "0.3.2"
 author        = "Andreas Rumpf"
 description   = "ZeroMQ wrapper"
 license       = "MIT"


### PR DESCRIPTION
Closes #17 

Change the dll match to `(lib)zmq.dll` for windows.
The packages at https://zeromq.org/download/ provide `libzmq-(compiler-version).dll` for windows.
Installing with `conda` (which is a pretty common way of ending up with zmq in path, as it is installed when installing ipython and jupyter installs it as `libzmq.dll`