### PR TITLE
Adding async to zmq package

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,40 @@
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  gh-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: "gh-pages"
+      - name: "install_nim"
+        id: install_nim
+        uses: iffy/install-nim@v3
+      - name: Set CI config github
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+      - name: Fetch
+        run: git fetch
+      - name: Rebase
+        run: git rebase -Xours origin/master
+      - name: NimbleDevelop
+        run: nimble develop -y
+      - name: Gendoc
+        run: nimble doc --project zmq.nim --out:docs/
+        env:
+      - name: Commit files
+        run: |
+          echo ${{ github.ref }}
+          git add -f docs
+          git commit -m "CI: Automated build push" -a | exit 0
+      - name: Force push to destination branch
+        uses: ad-m/github-push-action@v0.5.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages
+          force: true
+          directory: ./docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,6 @@ jobs:
         run: nimble develop -y
       - name: Gendoc
         run: nimble doc --project zmq.nim --out:docs/
-        env:
       - name: Commit files
         run: |
           echo ${{ github.ref }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: iffy/install-nim@v3
       - run: nimble install -y
-      - run: testament r tests/tzmq.nim
-      - run: testament p "examples/ex*.nim"
-      - run: nimble doc --project zmq.nim --out:docs/
+      - run: nimble test
+      - run: nimble runexamples
+      - run: nimble gendoc

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,4 +14,5 @@ jobs:
       - uses: iffy/install-nim@v3
       - run: nimble install -y
       - run: testament r tests/tzmq.nim
-      - run: testament c examples
+      - run: testament p "examples/ex*.nim"
+      - run: nimble doc --project zmq.nim --out:docs/

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,3 @@
+*
+!index.html
+!.gitignore

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
  <html>
 
    <head>
-     <title>Nim ZMQ Bindings</title>
+     <title>Nim-ZMQ</title>
    </head>
 
    <body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML>
+ <html>
+
+   <head>
+     <title>Nim ZMQ Bindings</title>
+   </head>
+
+   <body>
+     <meta http-equiv = "refresh" content = " 0 ; url = zmq.html"/>
+   </body>
+
+ </html>

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -2,6 +2,7 @@ bin/
 ex01_client_server
 ex02_reqrep
 ex03_sub
+sub_ex03_externals
 ex04_pubsub
 ex05_poller
 ex06_pollermultipart

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -6,5 +6,8 @@ ex04_pubsub
 ex05_poller
 ex06_pollermultipart
 ex07_marshalling
+ex08_async_reqrep
+ex09_async_pubsub
+ex10_async_pushpull
 nimcache/
 testresults/

--- a/examples/ex01_client_server.nim
+++ b/examples/ex01_client_server.nim
@@ -2,6 +2,7 @@ import ../zmq
 
 proc server() =
   var responder = zmq.listen("tcp://127.0.0.1:5555", REP)
+  defer:responder.close()
   var num_msg = 0
   while num_msg <= 10:
     var request = receive(responder)
@@ -9,16 +10,15 @@ proc server() =
     send(responder, "World")
     inc(num_msg)
 
-  close(responder)
-
 proc client() =
   var requester = zmq.connect("tcp://127.0.0.1:5555", REQ)
+  defer: requester.close()
+
   for i in 0..10:
     echo("Sending hello... (" & $i & ")")
     send(requester, "Hello")
     var reply = receive(requester)
     echo("Received: ", reply)
-  close(requester)
 
 when isMainModule:
   echo "ex01_client_server.nim"

--- a/examples/ex01_client_server.nim
+++ b/examples/ex01_client_server.nim
@@ -21,6 +21,7 @@ proc client() =
   close(requester)
 
 when isMainModule:
+  echo "ex01_client_server.nim"
   var thr: Thread[void]
   createThread(thr, server)
   client()

--- a/examples/ex01_client_server.nim
+++ b/examples/ex01_client_server.nim
@@ -1,4 +1,4 @@
-import zmq
+import ../zmq
 
 proc server() =
   var responder = zmq.listen("tcp://127.0.0.1:5555", REP)

--- a/examples/ex02_reqrep.nim
+++ b/examples/ex02_reqrep.nim
@@ -12,10 +12,7 @@ proc requester() =
 
   echo "sent: ", input
 
-  var requester = listen("tcp://127.0.0.1:5556", mode = REQ)
-
-  #var tt : int64 = getsockopt[int64](requester, TYPE)
-  #echo tt.TSocketType
+  var requester = listen("tcp://127.0.0.1:5555", mode = REQ)
 
   for i, e in input:
     if i < input.len-1:
@@ -26,7 +23,7 @@ proc requester() =
 
 # An example receiving message until they are no more
 proc responder(){.thread.} =
-  var responder = connect("tcp://127.0.0.1:5556", mode = REP)
+  var responder = connect("tcp://127.0.0.1:5555", mode = REP)
 
   var data: seq[float]
   # Loop until there is no more message to receive
@@ -41,6 +38,7 @@ proc responder(){.thread.} =
   echo "received: ", data
 
 when isMainModule:
+  echo "ex02_reqrep.nim"
   var thr: Thread[void]
   createThread(thr, responder)
   requester()

--- a/examples/ex02_reqrep.nim
+++ b/examples/ex02_reqrep.nim
@@ -1,6 +1,6 @@
-import strutils
+import std/strutils
 
-import zmq
+import ../zmq
 
 const num_elem = 12
 # An example of serialization using SNDMORE

--- a/examples/ex02_reqrep.nim
+++ b/examples/ex02_reqrep.nim
@@ -10,20 +10,21 @@ proc requester() =
   for i, elem in input.mpairs:
     elem = i/10
 
-  echo "sent: ", input
-
-  var requester = listen("tcp://127.0.0.1:5555", mode = REQ)
+  var requester = connect("tcp://127.0.0.1:15555", mode = REQ)
 
   for i, e in input:
     if i < input.len-1:
       requester.send($e, SNDMORE)
     else:
       requester.send($e)
+
+  echo "sent: ", input
+
   close(requester)
 
 # An example receiving message until they are no more
 proc responder(){.thread.} =
-  var responder = connect("tcp://127.0.0.1:5555", mode = REP)
+  var responder = listen("tcp://127.0.0.1:15555", mode = REP)
 
   var data: seq[float]
   # Loop until there is no more message to receive

--- a/examples/ex03_sub.nim
+++ b/examples/ex03_sub.nim
@@ -1,4 +1,4 @@
-import zmq
+import ../zmq
 
 var relay = "tcp://relay-us-west-1.eve-emdr.com:8050"
 

--- a/examples/ex04_pubsub.nim
+++ b/examples/ex04_pubsub.nim
@@ -40,6 +40,7 @@ proc subscriber(args: tuple[thrid: int, topic: string]){.thread.} =
 
 
 when isMainModule:
+  echo "ex04_pubsub.nim"
   var thr: array[num_thread, Thread[tuple[thrid: int, topic: string]]]
   for i in 0..<len(thr):
     createThread(thr[i], subscriber, (i, topics[i]))

--- a/examples/ex04_pubsub.nim
+++ b/examples/ex04_pubsub.nim
@@ -1,5 +1,5 @@
-import os
-import zmq
+import std/os
+import ../zmq
 
 const max_msg = 12
 const num_thread = 2

--- a/examples/ex05_poller.nim
+++ b/examples/ex05_poller.nim
@@ -1,6 +1,5 @@
 import std/strutils
 import std/os
-import std/system
 import ../zmq
 
 const address = "tcp://127.0.0.1:5558"

--- a/examples/ex05_poller.nim
+++ b/examples/ex05_poller.nim
@@ -42,6 +42,7 @@ proc client() =
   d2.close()
 
 when isMainModule:
+  echo "ex05_poller.nim"
   # Create router connexion
   var router = listen(address, mode = ROUTER)
 

--- a/examples/ex05_poller.nim
+++ b/examples/ex05_poller.nim
@@ -1,7 +1,7 @@
-import strutils
-import zmq
-import os
-import system
+import std/strutils
+import std/os
+import std/system
+import ../zmq
 
 const address = "tcp://127.0.0.1:5558"
 const max_msg = 10

--- a/examples/ex06_pollermultipart.nim
+++ b/examples/ex06_pollermultipart.nim
@@ -48,6 +48,7 @@ proc client() =
   echo "CLIENT -- END"
 
 when isMainModule:
+  echo "ex06_pollermultipart.nim"
   # Create router connexion
   var router = listen(address, mode = ROUTER)
 

--- a/examples/ex06_pollermultipart.nim
+++ b/examples/ex06_pollermultipart.nim
@@ -16,7 +16,9 @@ proc receiveMultipart(socket: ZSocket, flags: ZSendRecvOptions): seq[string] =
 
 proc client() =
   var d1 = connect(address, mode = DEALER)
+  defer: d1.close()
   var d2 = connect(address, mode = DEALER)
+  defer: d2.close()
 
   # Send a dummy message withc each socket to obtain the identity on the ROUTER socket
   d1.send("dummy")
@@ -27,6 +29,7 @@ proc client() =
   var poller: ZPoller
   poller.register(d1, ZMQ_POLLIN)
   poller.register(d2, ZMQ_POLLIN)
+
   while true:
     let res = poll(poller, 1_000)
     if res > 0:

--- a/examples/ex06_pollermultipart.nim
+++ b/examples/ex06_pollermultipart.nim
@@ -1,7 +1,6 @@
 import std/strutils
-import std/os
-import std/system
 import std/strformat
+import std/os
 import ../zmq
 
 const address = "tcp://127.0.0.1:5559"

--- a/examples/ex06_pollermultipart.nim
+++ b/examples/ex06_pollermultipart.nim
@@ -1,8 +1,8 @@
-import strutils
-import zmq
-import os
-import system
-import strformat
+import std/strutils
+import std/os
+import std/system
+import std/strformat
+import ../zmq
 
 const address = "tcp://127.0.0.1:5559"
 const max_msg = 10

--- a/examples/ex07_marshalling.nim
+++ b/examples/ex07_marshalling.nim
@@ -1,5 +1,5 @@
-import marshal
-import zmq
+import std/marshal # Marshall module is used as an example but is actually a very bad way of doing serialization
+import ../zmq
 
 type
   Person = object

--- a/examples/ex07_marshalling.nim
+++ b/examples/ex07_marshalling.nim
@@ -32,4 +32,5 @@ proc mainMarshal() =
     echo person
 
 when isMainModule:
+  echo "ex07_marshalling.nim"
   mainMarshal()

--- a/examples/ex08_async_reqrep.nim
+++ b/examples/ex08_async_reqrep.nim
@@ -37,6 +37,7 @@ proc responder(): Future[void] {.async.} =
     responder.send(request)
 
 when isMainModule:
+  echo "ex08_async_reqrep.nim"
   asyncCheck responder()
 
   for i in 1 .. N_REQUESTER:

--- a/examples/ex08_async_reqrep.nim
+++ b/examples/ex08_async_reqrep.nim
@@ -1,14 +1,13 @@
-import asyncdispatch
-import strformat
-import zmq
-import zmq_async
+import std/asyncdispatch
+import std/strformat
+import ../zmq
 
 const N_REQUESTER = 2
 const N_REQ_PER_REQUESTER = 3
 
 proc requester(id: int): Future[void] {.async.} =
   const connStr = "tcp://localhost:5555"
-  
+
   echo fmt"requester {id}: connecting to {connStr}"
   var requester = connect(connStr, REQ)
   defer: requester.close()
@@ -18,7 +17,7 @@ proc requester(id: int): Future[void] {.async.} =
     let msg = fmt"msg-{id}-{i}"
     echo fmt"requester {id}: sending {msg} to responder"
 
-    # specifies that the operation should be performed in non-blocking mode. 
+    # specifies that the operation should be performed in non-blocking mode.
     # If the message cannot be queued on the socket, send() shall fail with errno set to EAGAIN.
     requester.send(msg)
 
@@ -39,9 +38,9 @@ proc responder(): Future[void] {.async.} =
 
 when isMainModule:
   asyncCheck responder()
-  
+
   for i in 1 .. N_REQUESTER:
     asyncCheck requester(i)
-  
+
   while hasPendingOperations():
     poll()

--- a/examples/ex08_async_reqrep.nim
+++ b/examples/ex08_async_reqrep.nim
@@ -6,7 +6,7 @@ const N_REQUESTER = 2
 const N_REQ_PER_REQUESTER = 3
 
 proc requester(id: int): Future[void] {.async.} =
-  const connStr = "tcp://localhost:5555"
+  const connStr = "tcp://localhost:5570"
 
   echo fmt"requester {id}: connecting to {connStr}"
   var requester = connect(connStr, REQ)
@@ -27,7 +27,7 @@ proc requester(id: int): Future[void] {.async.} =
 
 proc responder(): Future[void] {.async.} =
   # listen on port 5555
-  var responder = listen("tcp://*:5555", REP)
+  var responder = listen("tcp://*:5570", REP)
   defer: responder.close()
 
   for i in 1 .. N_REQ_PER_REQUESTER * N_REQUESTER:

--- a/examples/ex09_async_pubsub.nim
+++ b/examples/ex09_async_pubsub.nim
@@ -5,7 +5,7 @@ import ../zmq
 const N_EVENT = 5
 
 proc subscriber(id: int): Future[void] {.async.} =
-  const connStr = "tcp://localhost:5555"
+  const connStr = "tcp://localhost:5571"
 
   # subscribe to port 5555
   echo fmt"subscriber {id}: connecting to {connStr}"
@@ -23,7 +23,7 @@ proc subscriber(id: int): Future[void] {.async.} =
 
 proc publisher(): Future[void] {.async.} =
   # listen on port 5555
-  var publisher = zmq.listen("tcp://*:5555", PUB)
+  var publisher = zmq.listen("tcp://*:5571", PUB)
   defer: publisher.close()
 
   for i in 1 .. N_EVENT:

--- a/examples/ex09_async_pubsub.nim
+++ b/examples/ex09_async_pubsub.nim
@@ -1,13 +1,12 @@
-import asyncdispatch
-import strformat
-import zmq
-import zmq_async
+import std/asyncdispatch
+import std/strformat
+import ../zmq
 
 const N_EVENT = 5
-  
+
 proc subscriber(id: int): Future[void] {.async.} =
   const connStr = "tcp://localhost:5555"
-  
+
   # subscribe to port 5555
   echo fmt"subscriber {id}: connecting to {connStr}"
   var subscriber = zmq.connect(connStr, SUB)
@@ -37,7 +36,7 @@ when isMainModule:
   asyncCheck publisher()
   for i in 1..3:
     asyncCheck subscriber(i)
-  
+
   while hasPendingOperations():
     poll()
 

--- a/examples/ex09_async_pubsub.nim
+++ b/examples/ex09_async_pubsub.nim
@@ -33,6 +33,7 @@ proc publisher(): Future[void] {.async.} =
     await sleepAsync(1000)
 
 when isMainModule:
+  echo "ex09_async_pubsub.nim"
   asyncCheck publisher()
   for i in 1..3:
     asyncCheck subscriber(i)

--- a/examples/ex10_async_pushpull.nim
+++ b/examples/ex10_async_pushpull.nim
@@ -1,4 +1,4 @@
-import std/strformat
+import std/[strformat]
 import std/asyncdispatch
 
 import ../zmq
@@ -32,6 +32,7 @@ proc puller(id: int): Future[void] {.async.} =
 when isMainModule:
   echo "ex10_async_pushpull.nim"
   asyncCheck pusher(N_TASK)
+
   for i in 1..1:
     asyncCheck puller(i)
 

--- a/examples/ex10_async_pushpull.nim
+++ b/examples/ex10_async_pushpull.nim
@@ -30,6 +30,7 @@ proc puller(id: int): Future[void] {.async.} =
     echo fmt"puller {id}: finished {task}"
 
 when isMainModule:
+  echo "ex10_async_pushpull.nim"
   asyncCheck pusher(N_TASK)
   for i in 1..1:
     asyncCheck puller(i)

--- a/examples/ex10_async_pushpull.nim
+++ b/examples/ex10_async_pushpull.nim
@@ -1,7 +1,7 @@
-import strformat
-import asyncdispatch
-import zmq
-import zmq_async
+import std/strformat
+import std/asyncdispatch
+
+import ../zmq
 
 const N_TASK = 5
 
@@ -13,9 +13,9 @@ proc pusher(nTask: int): Future[void] {.async.} =
     let task = fmt"task-{i}"
     echo fmt"pusher: pushing {task}"
     # unlilke `pusher.send(task)`
-    # this allow other async tasks to run 
+    # this allow other async tasks to run
     await pusher.sendAsync(task)
-    
+
 proc puller(id: int): Future[void] {.async.} =
   const connStr = "tcp://localhost:5555"
 
@@ -28,7 +28,7 @@ proc puller(id: int): Future[void] {.async.} =
     echo fmt"puller {id}: received {task}"
     await sleepAsync(100)
     echo fmt"puller {id}: finished {task}"
-    
+
 when isMainModule:
   asyncCheck pusher(N_TASK)
   for i in 1..1:
@@ -36,4 +36,4 @@ when isMainModule:
 
   while hasPendingOperations():
     poll()
-  
+

--- a/examples/sub_ex03_externals.nim
+++ b/examples/sub_ex03_externals.nim
@@ -1,4 +1,5 @@
 import ../zmq
+# Rename file so pattern matching with testament doesn't pick it up
 
 var relay = "tcp://relay-us-west-1.eve-emdr.com:8050"
 

--- a/tests/tzmq.nim
+++ b/tests/tzmq.nim
@@ -1,4 +1,4 @@
-import zmq
+import ../zmq
 import os
 
 proc reqrep() =

--- a/zmq.nim
+++ b/zmq.nim
@@ -27,7 +27,7 @@
 ##
 ## The low-level C bindings can be found in `zmq/bindings <./zmq/bindings.html>`_
 ##
-## The high-level Connections API can be found in `zmq/connections <./connections.html>`_
+## The high-level Connections API can be found in `zmq/connections <./zmq/connections.html>`_
 ##
 ## The high-level Polling API can be found in `zmq/poller <./zmq/poller.html>`_
 ##

--- a/zmq.nim
+++ b/zmq.nim
@@ -23,10 +23,16 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-## Nim ZeroMQ wrapper. This file contains the low level C wrappers as well as some higher level constructs.
-## The higher level constructs are easily recognizable because they are the only ones that have documentation.
+## Nim ZeroMQ wrapper. This package contains the low level C wrappers as well as some higher level constructs.
 ##
-## Example
+## The low-level C bindings can be found in `zmq/bindings <./zmq/bindings.html>`_
+##
+## The high-level Connections API can be found in `zmq/connections <./connections.html>`_
+##
+## The high-level Polling API can be found in `zmq/poller <./zmq/poller.html>`_
+##
+## The Async API can be found in `zmq/asynczmq <./zmq/asynczmq.html>`_
+##
 runnableExamples:
   import zmq
   import std/[asyncdispatch, asyncfutures]
@@ -100,9 +106,12 @@ runnableExamples:
 
 import zmq/bindings
 export bindings
+
 import zmq/connections
 export connections
+
 import zmq/poller
 export poller
+
 import zmq/asynczmq
 export asynczmq

--- a/zmq.nim
+++ b/zmq.nim
@@ -23,35 +23,80 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-## Nim 0mq wrapper. This file contains the low level C wrappers as well as
-## some higher level constructs. The higher level constructs are easily
-## recognizable because they are the only ones that have documentation.
+## Nim ZeroMQ wrapper. This file contains the low level C wrappers as well as some higher level constructs.
+## The higher level constructs are easily recognizable because they are the only ones that have documentation.
 ##
-## Example of a client:
-##
-## .. code-block:: nim
-##   import zmq
-##
-##   var requester = zmq.connect("tcp://localhost:5555", REQ)
-##   echo("Connecting...")
-##   for i in 0..10:
-##     echo("Sending hello... (" & $i & ")")
-##     send(requester, "Hello")
-##     var reply = receive(requester)
-##     echo("Received: ", reply)
-##   close(requester)
-##
-## Example of a server:
-##
-## .. code-block:: nim
-##
-##   import zmq
-##   var responder = zmq.listen("tcp://*:5555", REP)
-##   while true:
-##     var request = receive(responder)
-##     echo("Received: ", request)
-##     send(responder, "World")
-##   close(responder)
+## Example
+runnableExamples:
+  import zmq
+  import std/[asyncdispatch, asyncfutures]
+
+  proc client () {.async.} =
+    var requester = zmq.connect("tcp://localhost:5555", REQ)
+    echo("Connecting...")
+    for i in 0..10:
+      echo("Sending hello... (" & $i & ")")
+      send(requester, "Hello")
+      var reply = await receiveAsync(requester)
+      echo("Received: ", reply)
+
+    send(requester, "STOPSERVER")
+    close(requester)
+
+  proc server() : Future[int] {.async.} =
+    var responder = zmq.listen("tcp://*:5555", REP)
+    while true:
+      var request = await receiveAsync(responder)
+      if request == "STOPSERVER": break
+      echo("Received: ", request)
+      send(responder, "World")
+      inc(result)
+    close(responder)
+
+  let r = server()
+  asyncCheck client()
+  let res = waitFor r
+  echo "Server processed ", $(res), " requests"
+
+
+## Based on std/asyncdispatch, ``receiveAsync``, ``sendAsync`` allows for asynchrone behaviour
+## When using asynchrone procs, be careful of the internal state of the ZMQ Socket.
+## Some Socket (such as REP/REQ) cannot send two message in a row without a receive (or vice-versa)
+runnableExamples:
+  import std/asyncdispatch
+  import zmq
+
+  const N_TASK = 5
+
+  proc pusher(nTask: int): Future[void] {.async.} =
+    var pusher = listen("tcp://localhost:15555", PUSH)
+    defer: pusher.close()
+
+    for i in 1..nTask:
+      let task = "task-" & $i
+      # unlilke `pusher.send(task)`
+      # this allow other async tasks to run
+      await pusher.sendAsync(task)
+
+  proc puller(id: int): Future[void] {.async.} =
+    const connStr = "tcp://localhost:15555"
+    var puller = connect(connStr, PULL)
+    defer: puller.close()
+
+    for i in 1 .. N_TASK:
+      let task = await puller.receiveAsync()
+      echo "Pull socket n°", $id, " received ", task
+      await sleepAsync(100)
+
+  when isMainModule:
+    asyncCheck pusher(N_TASK)
+    for i in 1..1:
+      asyncCheck puller(i)
+
+    while hasPendingOperations():
+      poll()
+
+## Find more examples in the ``examples`` and ``tests`` folder
 
 import zmq/bindings
 export bindings
@@ -59,4 +104,5 @@ import zmq/connections
 export connections
 import zmq/poller
 export poller
-
+import zmq/asynczmq
+export asynczmq

--- a/zmq.nimble
+++ b/zmq.nimble
@@ -8,12 +8,13 @@ license       = "MIT"
 # Dependencies
 requires "nim >= 0.18.0"
 
-task gendoc, "Generate documentation":
-  nimble doc --project zmq.nim --out:docs/
-
 task runexamples, "Run all examples":
   withDir "examples":
     for fstr in listFiles("."):
-      if fstr.endsWith(".nim") and fstr.startsWith("ex"):
+      echo fstr
+      if fstr.endsWith(".nim") and fstr.startsWith("./ex"):
         echo "running ", fstr
         selfExec("cpp -r -d:release " & fstr)
+
+task gendoc, "Generate documentation":
+  exec("nimble doc --project zmq.nim --out:docs/")

--- a/zmq.nimble
+++ b/zmq.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "1.0.1"
+version       = "1.1.0"
 author        = "Andreas Rumpf"
 description   = "ZeroMQ wrapper"
 license       = "MIT"

--- a/zmq.nimble
+++ b/zmq.nimble
@@ -7,3 +7,13 @@ license       = "MIT"
 
 # Dependencies
 requires "nim >= 0.18.0"
+
+task gendoc, "Generate documentation":
+  nimble doc --project zmq.nim --out:docs/
+
+task runexamples, "Run all examples":
+  withDir "examples":
+    for fstr in listFiles("."):
+      if fstr.endsWith(".nim") and fstr.startsWith("ex"):
+        echo "running ", fstr
+        selfExec("cpp -r -d:release " & fstr)

--- a/zmq/asynczmq.nim
+++ b/zmq/asynczmq.nim
@@ -1,5 +1,6 @@
-import asyncdispatch
-import zmq
+import std/asyncdispatch
+import ./connections
+import ./bindings
 
 proc receiveAsync*(conn: ZConnection): Future[string] =
   ## Similar to `receive()`, but `receiveAsync()` allows other async tasks to run.
@@ -10,7 +11,7 @@ proc receiveAsync*(conn: ZConnection): Future[string] =
     result = true
 
     # ignore if already finished
-    if fut.finished: return 
+    if fut.finished: return
 
     try:
       let status = getsockopt[cint](conn, ZSockOptions.EVENTS)
@@ -30,7 +31,7 @@ proc receiveAsync*(conn: ZConnection): Future[string] =
   discard cb(fd)
 
 proc sendAsync*(conn: ZConnection, msg: string, flags: ZSendRecvOptions = DONTWAIT): Future[void] =
-  ## `send()` is blocking for some connection types (e.g. PUSH, DEALER). 
+  ## `send()` is blocking for some connection types (e.g. PUSH, DEALER).
   ## `sendAsync()` allows other async tasks to run in those cases.
   let fut = newFuture[void]("sendAsync")
   result = fut
@@ -42,7 +43,7 @@ proc sendAsync*(conn: ZConnection, msg: string, flags: ZSendRecvOptions = DONTWA
       result = true
 
       # ignore if already finished
-      if fut.finished: return 
+      if fut.finished: return
 
       try:
         let status = getsockopt[cint](conn, ZSockOptions.EVENTS)
@@ -60,6 +61,7 @@ proc sendAsync*(conn: ZConnection, msg: string, flags: ZSendRecvOptions = DONTWA
     let fd = getsockopt[cint](conn, ZSockOptions.FD).AsyncFD
     register(fd)
     discard cb(fd)
+
   else:
     # can send without blocking
     conn.send(msg, flags)

--- a/zmq/bindings.nim
+++ b/zmq/bindings.nim
@@ -160,7 +160,7 @@ proc zmq_msg_t_size(dotted_version: string): int =
 type
   ZMsg* {.pure, final.} = object
     priv*: array[zmq_msg_t_size(make_dotted_version(ZMQ_VERSION_MAJOR,
-        ZMQ_VERSION_MINOR, ZMQ_VERSION_PATCH)), cuchar]
+        ZMQ_VERSION_MINOR, ZMQ_VERSION_PATCH)), uint8]
 
   TFreeFn = proc (data, hint: pointer) {.noconv.}
 

--- a/zmq/connections.nim
+++ b/zmq/connections.nim
@@ -1,4 +1,5 @@
-import bindings
+import ./bindings
+
 # Unofficial easier-for-Nim API
 
 #[
@@ -143,15 +144,16 @@ proc connect*(address: string, mode: ZSocketType, context: ZContext): ZConnectio
 proc connect*(address: string, mode: ZSocketType): ZConnection =
   ## Open a new connection on an internal (owned) ``ZContext`` and connects the socket
   runnableExamples:
-    var pullcon = connect("tcp://127.0.0.1:34444", pull)
-    var pushcon = listen("tcp://127.0.0.1:34444", push)
+    import zmq
+    var pull_conn = connect("tcp://127.0.0.1:34444", PULL)
+    var push_conn = listen("tcp://127.0.0.1:34444", PUSH)
 
     let msgpayload = "hello world !"
-    pushcon.send(msgpayload)
-    assert pullcon.receive() == msgpayload
+    push_conn.send(msgpayload)
+    assert pull_conn.receive() == msgpayload
 
-    pushcon.close()
-    pullcon.close()
+    push_conn.close()
+    pull_conn.close()
 
   let ctx = ctx_new()
   if ctx == nil:
@@ -163,6 +165,7 @@ proc connect*(address: string, mode: ZSocketType): ZConnection =
 proc listen*(address: string, mode: ZSocketType, context: ZContext): ZConnection =
   ## Open a new connection on an external ``ZContext`` and binds on the socket
   runnableExamples:
+    import zmq
     var monoserver = listen("tcp://127.0.0.1:34444", PAIR)
     var monoclient = connect("tcp://127.0.0.1:34444", PAIR)
 

--- a/zmq/poller.nim
+++ b/zmq/poller.nim
@@ -1,6 +1,6 @@
-import bindings
-import connections
-import bitops
+import ./bindings
+import ./connections
+import std/bitops
 
 # Unofficial easier-for-Nim API
 # ZPoller type


### PR DESCRIPTION
* The async proc were already done by @jackhftang but added to the examples folder and thus not accessible (which is a shame beause it's very useful).
* Added std/ prefix before import.
* ~~Fix a missing a close in examples that could cause CI to hang indefinitely~~ apparently not fixed
* Added runnable exmaples instead of code block and added examples in the documentation
* Added CI to generate docs -> @Araq At your leisure, this requires  :  
  * creating ``gh-pages`` branch 
  * enabling github pages for the ``gh-pages`` branch on the ``docs`` folder. 
  * Adding link to the docs in relevant places such as website repo, readme etc.
  * The result can be seen in my fork https://clonkk.github.io/nim-zmq/zmq.html.

=> If you don't want to generate the docs, this can be removed from this PR.

* Bump to version v1.1.0