### PR TITLE
Async comment, proxy API

### DIFF
--- a/examples/ex06_pollermultipart.nim
+++ b/examples/ex06_pollermultipart.nim
@@ -6,13 +6,6 @@ import ../zmq
 const address = "tcp://127.0.0.1:5559"
 const max_msg = 10
 
-proc receiveMultipart(socket: ZSocket, flags: ZSendRecvOptions): seq[string] =
-  # Little trick to receive all multipart message no matter how many parts there is using getsockopt
-  var hasMore: int = 1
-  while hasMore > 0:
-    result.add(socket.receive())
-    hasMore = getsockopt[int](socket, RCVMORE)
-
 
 proc client() =
   var d1 = connect(address, mode = DEALER)
@@ -35,7 +28,7 @@ proc client() =
     if res > 0:
       for i in 0..<len(poller):
         if events(poller[i]):
-          let buf = receiveMultipart(poller[i].socket, NOFLAGS)
+          let buf = receiveAll(poller[i].socket, NOFLAGS)
           for j, msg in buf.pairs:
             echo &"CLIENT> Socket{i} received \"{msg}\""
         else:

--- a/tests/tzmq.nim
+++ b/tests/tzmq.nim
@@ -1,134 +1,190 @@
 import ../zmq
-import os
+import std/[unittest, os]
 
 proc reqrep() =
-  const sockaddr = "tcp://127.0.0.1:55001"
-  let
-    ping = "ping"
-    pong = "pong"
+  test "reqrep":
+    const sockaddr = "tcp://127.0.0.1:55001"
+    let
+      ping = "ping"
+      pong = "pong"
 
-  var
-    rep = listen(sockaddr, REP)
-    req = connect(sockaddr, REQ)
+    var rep = listen(sockaddr, REP)
+    defer: rep.close()
+    var req = connect(sockaddr, REQ)
+    defer: req.close()
 
-  req.send(ping)
-  assert rep.receive() == ping
-  rep.send(pong)
-  assert req.receive() == pong
-
-  rep.close()
-  req.close()
+    block:
+      req.send(ping)
+      let r = rep.receive()
+      check r == ping
+    block:
+      rep.send(pong)
+      let r = req.receive()
+      check r == pong
 
 proc pubsub() =
-  const sockaddr = "tcp://127.0.0.1:55001"
-  let
-    topic1 = "topic1"
-    topic2 = "topic2"
+  test "pubsub":
+    const sockaddr = "tcp://127.0.0.1:55001"
+    let
+      topic1 = "topic1"
+      topic2 = "topic2"
 
-  var pub = listen(sockaddr, PUB)
-  var
-    broadcast = connect(sockaddr, SUB)
-    sub1 = connect(sockaddr, SUB)
-    sub2 = connect(sockaddr, SUB)
-  # Subscribe to all topic
-  broadcast.setsockopt(SUBSCRIBE, "")
-  # Subscribe to topic
-  sub1.setsockopt(SUBSCRIBE, topic1)
-  sub2.setsockopt(SUBSCRIBE, topic2)
+    var pub = listen(sockaddr, PUB)
+    defer: pub.close()
+    var broadcast = connect(sockaddr, SUB)
+    defer: broadcast.close()
+    var sub1 = connect(sockaddr, SUB)
+    defer: sub1.close()
+    var sub2 = connect(sockaddr, SUB)
+    defer: sub2.close()
+    # Subscribe to all topic
+    broadcast.setsockopt(SUBSCRIBE, "")
+    # Subscribe to topic
+    sub1.setsockopt(SUBSCRIBE, topic1)
+    sub2.setsockopt(SUBSCRIBE, topic2)
 
-  # Slow-joiner pattern -> PUB / SUB Pattern needs a bit of time to establish connection
-  sleep(200)
+    # Slow-joiner pattern -> PUB / SUB Pattern needs a bit of time to establish connection
+    sleep(200)
 
-  # Topic1
-  pub.send(topic1, SNDMORE)
-  pub.send("content1")
-  block alltopic:
-    let topic = broadcast.receive()
-    let msg = broadcast.receive()
-    assert  topic == topic1
-    assert msg == "content1"
-  block s1:
-    let topic = sub1.receive()
-    let msg = sub1.receive()
-    assert topic == topic1
-    assert msg == "content1"
+    # Topic1
+    pub.send(topic1, SNDMORE)
+    pub.send("content1")
+    block alltopic:
+      let topic = broadcast.receive()
+      let msg = broadcast.receive()
+      check  topic == topic1
+      check msg == "content1"
+    block s1:
+      let topic = sub1.receive()
+      let msg = sub1.receive()
+      check topic == topic1
+      check msg == "content1"
 
-  # Topic2
-  pub.send(topic2, SNDMORE)
-  pub.send("content2")
-  block alltopic:
-    let topic = broadcast.receive()
-    let msg = broadcast.receive()
-    assert  topic == topic2
-    assert msg == "content2"
-  block s2:
-    let topic = sub2.receive()
-    let msg = sub2.receive()
-    assert topic == topic2
-    assert msg == "content2"
+    # Topic2
+    pub.send(topic2, SNDMORE)
+    pub.send("content2")
+    block alltopic:
+      let topic = broadcast.receive()
+      let msg = broadcast.receive()
+      check  topic == topic2
+      check msg == "content2"
+    block s2:
+      let topic = sub2.receive()
+      let msg = sub2.receive()
+      check topic == topic2
+      check msg == "content2"
 
-  # Broadcast
-  pub.send("", SNDMORE)
-  pub.send("content3")
-  block alltopic:
-    let topic = broadcast.receive()
-    let msg = broadcast.receive()
-    assert  topic == ""
-    assert msg == "content3"
-
-  sub1.close()
-  sub2.close()
-  broadcast.close()
-  pub.close()
+    # Broadcast
+    pub.send("", SNDMORE)
+    pub.send("content3")
+    block alltopic:
+      let topic = broadcast.receive()
+      let msg = broadcast.receive()
+      check  topic == ""
+      check msg == "content3"
 
 proc routerdealer() =
-  const sockaddr = "tcp://127.0.0.1:55001"
-  var router = listen(sockaddr, mode = ROUTER)
-  var dealer = connect(sockaddr, mode = DEALER)
+  test "routerdealer":
+    const sockaddr = "tcp://127.0.0.1:55001"
+    var router = listen(sockaddr, mode = ROUTER)
+    router.setsockopt(RCVTIMEO, 350.cint)
+    defer: router.close()
+    var dealer = connect(sockaddr, mode = DEALER)
+    defer: dealer.close()
 
-  let payload = "payload"
-  # Dealer send a message to router
-  dealer.send(payload)
-  # Remove "envelope" of router / dealer
-  let dealerSocketId = router.receive()
-  let msg = router.receive()
-  assert msg == payload
-  # Reply to the Dealer
-  router.send(dealerSocketId, SNDMORE)
-  router.send(payload)
-  assert dealer.receive() == payload
+    let payload = "payload"
+    # Dealer send a message to router
+    dealer.send(payload)
+    # Remove "envelope" of router / dealer
+    let dealerSocketId = router.receive()
+    let msg = router.receive()
+    check msg == payload
+    # Reply to the Dealer
+    router.send(dealerSocketId, SNDMORE)
+    router.send(payload)
+    check dealer.receive() == payload
+    # Let receive timeout
+    block:
+      # On receive return empty message
+      let recv = router.receive()
+      check recv == ""
+    block:
+      # On try receive, check flag is flase
+      let recv = router.tryReceive()
+      check recv.msgAvailable == false
 
 proc inproc_sharectx() =
-  # AFAIK, inproc only works for Linux
-  when defined(linux):
-    # Check sharing context works for inproc
+  test "inproc":
+    # AFAIK, inproc only works for Linux
+    when defined(linux):
+      # Check sharing context works for inproc
+      let
+        inprocpath = getTempDir() / "nimzmq"
+        sockaddr = "inproc://" & inprocpath
+      var
+        server = listen(sockaddr, PAIR)
+        client = connect(sockaddr, PAIR, server.context)
+
+      client.send("Hello")
+      check server.receive() == "Hello"
+      server.send("World")
+      check client.receive() == "World"
+
+      client.close()
+      server.close()
+
+    else:
+      discard
+
+proc pairpair() =
+  test "pairpair_sndmore":
+    const sockaddr = "tcp://127.0.0.1:55001"
     let
-      inprocpath = getTempDir() / "nimzmq"
-      sockaddr = "inproc://" & inprocpath
-    var
-      server = listen(sockaddr, PAIR)
-      client = connect(sockaddr, PAIR, server.context)
+      ping = "ping"
+      pong = "pong"
 
-    client.send("Hello")
-    assert server.receive() == "Hello"
-    server.send("World")
-    assert client.receive() == "World"
+    var pairs = @[listen(sockaddr, PAIR), connect(sockaddr, PAIR)]
+    pairs[1].setsockopt(RCVTIMEO, 500.cint)
+    block:
+      pairs[0].send(ping, SNDMORE)
+      pairs[0].send(ping, SNDMORE)
+      pairs[0].send(ping)
 
-    client.close()
-    server.close()
+    block:
+      let content = pairs[1].tryReceive()
+      check content.msgAvailable
+      check content.moreAvailable
+      check content.msg == ping
 
-  else:
-    discard
+    block:
+      let content = pairs[1].tryReceive()
+      check content.msgAvailable
+      check content.moreAvailable
+      check content.msg == ping
+
+    block:
+      let content = pairs[1].tryReceive()
+      check content.msgAvailable
+      check (not content.moreAvailable)
+      check content.msg == ping
+
+    block:
+      let content = pairs[1].tryReceive()
+      check (not content.msgAvailable)
+
+    block:
+      let msgs = [pong, pong, pong]
+      pairs[1].sendAll(msgs)
+      let contents = pairs[0].receiveAll()
+      check contents == msgs
+
+    for p in pairs.mitems:
+      p.close()
 
 when isMainModule:
-  block reqrep:
-    reqrep()
-  block pubsub:
-    pubsub()
-  block inproc:
-    inproc_sharectx()
-  block routerdealer:
-    routerdealer()
-  block poller:
-    discard
+  reqrep()
+  pubsub()
+  inproc_sharectx()
+  routerdealer()
+  pairpair()
 

--- a/zmq.nimble
+++ b/zmq.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "1.1.0"
+version       = "1.1.1"
 author        = "Andreas Rumpf"
 description   = "ZeroMQ wrapper"
 license       = "MIT"

--- a/zmq.nimble
+++ b/zmq.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "1.1.1"
+version       = "1.2.0"
 author        = "Andreas Rumpf"
 description   = "ZeroMQ wrapper"
 license       = "MIT"

--- a/zmq/asynczmq.nim
+++ b/zmq/asynczmq.nim
@@ -5,7 +5,9 @@ import ./bindings
 proc receiveAsync*(conn: ZConnection): Future[string] =
   ## Similar to `receive()`, but `receiveAsync()` allows other async tasks to run.
   ## `receiveAsync()` allows other async tasks to run in those cases.
-  ## This will not work in some case because it depends on ZMQ_FD which is not necessarily the 'tru' FD of the socket
+  ##
+  ## This will not work in some case because it depends on ZMQ_FD which is not necessarily the 'true' FD of the socket
+  ##
   ## See https://github.com/zeromq/libzmq/issues/2941 and https://github.com/zeromq/pyzmq/issues/1411
   let fut = newFuture[string]("receiveAsync")
   result = fut
@@ -36,7 +38,9 @@ proc receiveAsync*(conn: ZConnection): Future[string] =
 proc sendAsync*(conn: ZConnection, msg: string, flags: ZSendRecvOptions = DONTWAIT): Future[void] =
   ## `send()` is blocking for some connection types (e.g. PUSH, DEALER).
   ## `sendAsync()` allows other async tasks to run in those cases.
-  ## This will not work in some case because it depends on ZMQ_FD which is not necessarily the 'tru' FD of the socket
+  ##
+  ## This will not work in some case because it depends on ZMQ_FD which is not necessarily the 'true' FD of the socket
+  ##
   ## See https://github.com/zeromq/libzmq/issues/2941 and https://github.com/zeromq/pyzmq/issues/1411
   let fut = newFuture[void]("sendAsync")
   result = fut

--- a/zmq/asynczmq.nim
+++ b/zmq/asynczmq.nim
@@ -4,10 +4,13 @@ import ./bindings
 
 proc receiveAsync*(conn: ZConnection): Future[string] =
   ## Similar to `receive()`, but `receiveAsync()` allows other async tasks to run.
+  ## `receiveAsync()` allows other async tasks to run in those cases.
+  ## This will not work in some case because it depends on ZMQ_FD which is not necessarily the 'tru' FD of the socket
+  ## See https://github.com/zeromq/libzmq/issues/2941 and https://github.com/zeromq/pyzmq/issues/1411
   let fut = newFuture[string]("receiveAsync")
   result = fut
 
-  proc cb(fd: AsyncFD): bool {.closure,gcsafe.} =
+  proc cb(fd: AsyncFD): bool {.closure, gcsafe.} =
     result = true
 
     # ignore if already finished
@@ -33,13 +36,15 @@ proc receiveAsync*(conn: ZConnection): Future[string] =
 proc sendAsync*(conn: ZConnection, msg: string, flags: ZSendRecvOptions = DONTWAIT): Future[void] =
   ## `send()` is blocking for some connection types (e.g. PUSH, DEALER).
   ## `sendAsync()` allows other async tasks to run in those cases.
+  ## This will not work in some case because it depends on ZMQ_FD which is not necessarily the 'tru' FD of the socket
+  ## See https://github.com/zeromq/libzmq/issues/2941 and https://github.com/zeromq/pyzmq/issues/1411
   let fut = newFuture[void]("sendAsync")
   result = fut
 
   let status = getsockopt[cint](conn, ZSockOptions.EVENTS)
   if (status and ZMQ_POLLOUT) == 0:
     # wait until queue available
-    proc cb(fd: AsyncFD): bool {.closure,gcsafe.} =
+    proc cb(fd: AsyncFD): bool {.closure, gcsafe.} =
       result = true
 
       # ignore if already finished

--- a/zmq/bindings.nim
+++ b/zmq/bindings.nim
@@ -66,6 +66,7 @@ proc version*(major: var cint, minor: var cint, patch: var cint){.cdecl,
 #  of this function is to make the code 100% portable, including where 0MQ
 #  compiled with certain CRT library (on Windows) is linked to an
 #  application that uses different CRT library.
+let ZMQ_EAGAIN* {.importc: "EAGAIN", header: "errno.h".}: cint
 proc errno*(): cint{.cdecl, importc: "zmq_errno", dynlib: zmqdll.}
 
 #  Resolves system errors and 0MQ errors to human-readable string.
@@ -113,9 +114,9 @@ proc ctx_term*(context: ZContext): cint {.cdecl, importc: "zmq_ctx_term",
   dynlib: zmqdll.}
 proc ctx_shutdown*(ctx: ZContext): cint {.cdecl, importc: "zmq_ctx_shutdown",
   dynlib: zmqdll.}
-proc ctx_set*(context: ZContext; option: cint; optval: cint): cint {.cdecl,
+proc ctx_set*(context: ZContext, option: cint, optval: cint): cint {.cdecl,
   importc: "zmq_ctx_set", dynlib: zmqdll.}
-proc ctx_get*(context: ZContext; option: cint): cint {.cdecl,
+proc ctx_get*(context: ZContext, option: cint): cint {.cdecl,
   importc: "zmq_ctx_get", dynlib: zmqdll.}
 
 #  Old (legacy) API
@@ -188,14 +189,14 @@ sanity_check_libzmq()
 
 proc msg_init*(msg: var ZMsg): cint {.cdecl, importc: "zmq_msg_init",
   dynlib: zmqdll.}
-proc msg_init*(msg: var ZMsg; size: int): cint {.cdecl,
+proc msg_init*(msg: var ZMsg, size: int): cint {.cdecl,
   importc: "zmq_msg_init_size", dynlib: zmqdll.}
-proc msg_init*(msg: var ZMsg; data: cstring; size: int;
-                        ffn: TFreeFn; hint: pointer): cint {.cdecl,
+proc msg_init*(msg: var ZMsg, data: cstring, size: int,
+                        ffn: TFreeFn, hint: pointer): cint {.cdecl,
                         importc: "zmq_msg_init_data", dynlib: zmqdll.}
-proc msg_send*(msg: var ZMsg; s: ZSocket; flags: cint): cint {.cdecl,
+proc msg_send*(msg: var ZMsg, s: ZSocket, flags: cint): cint {.cdecl,
   importc: "zmq_msg_send", dynlib: zmqdll.}
-proc msg_recv*(msg: var ZMsg; s: ZSocket; flags: cint): cint {.cdecl,
+proc msg_recv*(msg: var ZMsg, s: ZSocket, flags: cint): cint {.cdecl,
   importc: "zmq_msg_recv", dynlib: zmqdll.}
 proc msg_close*(msg: var ZMsg): cint {.cdecl, importc: "zmq_msg_close",
   dynlib: zmqdll.}
@@ -209,10 +210,10 @@ proc msg_size*(msg: var ZMsg): int {.cdecl, importc: "zmq_msg_size",
   dynlib: zmqdll.}
 proc msg_more*(msg: var ZMsg): cint {.cdecl, importc: "zmq_msg_more",
   dynlib: zmqdll.}
-proc msg_get*(msg: var ZMsg; option: cint): cint {.cdecl,
+proc msg_get*(msg: var ZMsg, option: cint): cint {.cdecl,
     importc: "zmq_msg_get",
   dynlib: zmqdll.}
-proc msg_set*(msg: var ZMsg; option: cint; optval: cint): cint {.cdecl,
+proc msg_set*(msg: var ZMsg, option: cint, optval: cint): cint {.cdecl,
   importc: "zmq_msg_set", dynlib: zmqdll.}
 
 #****************************************************************************
@@ -478,17 +479,17 @@ proc bindAddr*(s: ZSocket, address: cstring): cint{.cdecl, importc: "zmq_bind",
       dynlib: zmqdll.}
 proc connect*(s: ZSocket, address: cstring): cint{.cdecl,
       importc: "zmq_connect", dynlib: zmqdll.}
-proc unbind*(s: ZSocket; address: cstring): cint {.cdecl, importc: "zmq_unbind",
+proc unbind*(s: ZSocket, address: cstring): cint {.cdecl, importc: "zmq_unbind",
       dynlib: zmqdll.}
-proc disconnect*(s: ZSocket; address: cstring): cint {.cdecl,
+proc disconnect*(s: ZSocket, address: cstring): cint {.cdecl,
       importc: "zmq_disconnect", dynlib: zmqdll.}
-proc send*(s: ZSocket; buf: pointer; len: int; flags: cint): cint {.cdecl,
+proc send*(s: ZSocket, buf: pointer, len: int, flags: cint): cint {.cdecl,
       importc: "zmq_send", dynlib: zmqdll.}
-proc send_const*(s: ZSocket; buf: pointer; len: int; flags: cint): cint {.cdecl,
+proc send_const*(s: ZSocket, buf: pointer, len: int, flags: cint): cint {.cdecl,
       importc: "zmq_send_const", dynlib: zmqdll.}
-proc recv*(s: ZSocket; buf: pointer; len: int; flags: cint): cint {.cdecl,
+proc recv*(s: ZSocket, buf: pointer, len: int, flags: cint): cint {.cdecl,
       importc: "zmq_recv", dynlib: zmqdll.}
-proc socket_monitor*(s: ZSocket; address: pointer; events: cint): cint {.cdecl,
+proc socket_monitor*(s: ZSocket, address: pointer, events: cint): cint {.cdecl,
       importc: "zmq_socket_monitor", dynlib: zmqdll.}
 
 proc sendmsg*(s: ZSocket, msg: var ZMsg, flags: cint): cint{.cdecl,
@@ -520,18 +521,18 @@ proc poll*(items: ptr UncheckedArray[ZPollItem], nitems: cint,
   cdecl, importc: "zmq_poll", dynlib: zmqdll.}
 
 #  Built-in message proxy (3-way)
-proc proxy*(frontend: ZSocket; backend: ZSocket; capture: ZSocket): cint {.
+proc proxy*(frontend: ZSocket, backend: ZSocket, capture: ZSocket): cint {.
   cdecl, importc: "zmq_proxy", dynlib: zmqdll.}
-proc proxy_steerable*(frontend: ZSocket; backend: ZSocket; capture: ZSocket;
+proc proxy_steerable*(frontend: ZSocket, backend: ZSocket, capture: ZSocket,
             control: ZSocket): cint {.cdecl, importc: "zmq_proxy_steerable",
     dynlib: zmqdll.}
 
 #  Encode a binary key as printable text using ZMQ RFC 32
-proc z85_encode*(dest: cstring; data: ptr uint8; size: int): cstring {.
+proc z85_encode*(dest: cstring, data: ptr uint8, size: int): cstring {.
   cdecl, importc: "zmq_z85_encode", dynlib: zmqdll.}
 
 #  Encode a binary key from printable text per ZMQ RFC 32
-proc z85_decode*(dest: ptr uint8; string: cstring): ptr uint8 {.
+proc z85_decode*(dest: ptr uint8, string: cstring): ptr uint8 {.
   cdecl, importc: "zmq_z85_decode", dynlib: zmqdll.}
 
 #  Deprecated aliases
@@ -540,5 +541,5 @@ proc z85_decode*(dest: ptr uint8; string: cstring): ptr uint8 {.
 #  ZMQ_FORWARDER* = 2
 #  ZMQ_QUEUE* = 3
 #  Deprecated method
-#proc zmq_device*(type: cint; frontend: pointer; backend: pointer): cint
+#proc zmq_device*(type: cint, frontend: pointer, backend: pointer): cint
 

--- a/zmq/bindings.nim
+++ b/zmq/bindings.nim
@@ -124,11 +124,11 @@ proc ctx_get*(context: ZContext; option: cint): cint {.cdecl,
 #proc zmq_ctx_destroy*(context: pointer): cint
 
 proc init*(io_threads: cint): ZContext {.cdecl, importc: "zmq_init",
-  dynlib: zmqdll.}
+                                         dynlib: zmqdll, deprecated: "Legacy API. Use ctx_new instead".}
 proc term*(context: ZContext): cint {.cdecl, importc: "zmq_term",
-                                      dynlib: zmqdll.}
+                                      dynlib: zmqdll, deprecated: "Legacy API. Use ctx_term instead".}
 proc ctx_destroy*(context: ZContext): cint {.cdecl, importc: "zmq_ctx_destroy",
-  dynlib: zmqdll.}
+                                             dynlib: zmqdll, deprecated: "Legacy API. Use ctx_term instead".}
 
 
 #****************************************************************************

--- a/zmq/connections.nim
+++ b/zmq/connections.nim
@@ -259,9 +259,15 @@ proc receive*(c: ZConnection, flags: ZSendRecvOptions = NOFLAGS): string =
   receive(c.socket, flags)
 
 proc proxy*(frontend, backend: ZConnection) =
+  ## The proxy connects a frontend socket to a backend socket. Data flows from frontend to backend.
+  ## Depending on the socket types, replies may flow in the opposite direction.
+  ## Before calling proxy(), you must set any socket options, and connect or bind both frontend and backend sockets. The two conventional proxy models are:
+  ## ``proxy()`` runs in the current thread and returns only if/when the current context is closed.
   discard proxy(frontend.socket, backend.socket, nil)
   zmqError()
 
 proc proxy*(frontend, backend, capture: ZConnection) =
+  ## Same as ``proxy(frontend, backend: ZConnection)`` but enable the use of a capture socket.
+  ## The proxy shall send all messages, received on both frontend and backend, to the capture socket. The capture socket should be a ZMQ_PUB, ZMQ_DEALER, ZMQ_PUSH, or ZMQ_PAIR socket.
   discard proxy(frontend.socket, backend.socket, capture.socket)
   zmqError()

--- a/zmq/connections.nim
+++ b/zmq/connections.nim
@@ -258,3 +258,10 @@ proc receive*(c: ZConnection, flags: ZSendRecvOptions = NOFLAGS): string =
   ## Receive data over the connection
   receive(c.socket, flags)
 
+proc proxy*(frontend, backend: ZConnection) =
+  discard proxy(frontend.socket, backend.socket, nil)
+  zmqError()
+
+proc proxy*(frontend, backend, capture: ZConnection) =
+  discard proxy(frontend.socket, backend.socket, capture.socket)
+  zmqError()

--- a/zmq/connections.nim
+++ b/zmq/connections.nim
@@ -305,7 +305,7 @@ proc tryReceive*(s: ZSocket, flags: ZSendRecvOptions = NOFLAGS): tuple[msgAvaila
     result.msgAvailable = true
     result.msg = newString(msg_size(m))
     if result.msg.len > 0:
-      copyMem(addr(result[0]), msg_data(m), result.msg.len)
+      copyMem(addr(result.msg[0]), msg_data(m), result.msg.len)
     result.moreAvailable = msg_more(m).bool
   else:
     # Either an error or EAGAIN

--- a/zmq/connections.nim
+++ b/zmq/connections.nim
@@ -220,14 +220,14 @@ proc listen*(address: string; mode: ZSocketType): ZConnection =
   result = listen(address, mode, ctx)
   result.ownctx = true
 
-proc close*(c: var ZConnection) =
+proc close*(c: var ZConnection; linger: int) =
   ## Closes the ``ZConnection``.
-  ## Set socket linger to 0 to drop buffered message and avoid blocking, then close the socket.
+  ## Set socket linger to ``linger`` to drop buffered message and avoid blocking, then close the socket.
   ##
   ## If the ``ZContext`` is owned by the connection, terminate the context as well.
   ##
   ## With --gc:arc/orc ``close`` must be called before ``ZConnection`` destruction or the``=destroy`` hook.
-  setsockopt(c, LINGER, 0.cint)
+  setsockopt(c, LINGER, linger.cint)
   if close(c.socket) != 0:
     zmqError()
   c.alive = false
@@ -235,6 +235,15 @@ proc close*(c: var ZConnection) =
   # Do not destroy embedded socket if it does not own it
   if c.ownctx:
     c.context.terminate()
+
+proc close*(c: var ZConnection) =
+  ## Closes the ``ZConnection``.
+  ## Set socket linger to 0 to drop buffered message and avoid blocking, then close the socket.
+  ##
+  ## If the ``ZContext`` is owned by the connection, terminate the context as well.
+  ##
+  ## With --gc:arc/orc ``close`` must be called before ``ZConnection`` destruction or the``=destroy`` hook.
+  close(c, 0)
 
 # Send / Receive
 # Send with ZSocket type

--- a/zmq/connections.nim
+++ b/zmq/connections.nim
@@ -30,7 +30,7 @@ proc zmqError*() {.noinline, noreturn.} =
 ]#
 proc newZContext*(): ZContext =
   ## Create a new ZContext
-  result = newZContext()
+  result = ctx_new()
 
 proc newZContext*(option: int; optval: int): ZContext =
   ## Create a new ZContext and set its options

--- a/zmq/connections.nim
+++ b/zmq/connections.nim
@@ -38,6 +38,10 @@ proc newZContext*(option: int; optval: int): ZContext =
   if result.ctx_set(option.cint, optval.cint) != 0:
     zmqError()
 
+proc newZContext*(numthreads: int): ZContext =
+  ## Create a new ZContext with a thread pool set to ``numthreads``
+  result = newZContext(ZMQ_IO_THREADS, numthreads)
+
 proc terminate*(ctx: ZContext) =
   ## Terminate the ZContext
   if ctx_term(ctx) != 0:

--- a/zmq/connections.nim
+++ b/zmq/connections.nim
@@ -268,7 +268,7 @@ proc send*(s: ZSocket, msg: string, flags: ZSendRecvOptions = NOFLAGS) =
     zmqError()
   # no close msg after a send
 
-proc sendAll*(s: ZSocket, msg: openArray[string]) =
+proc sendAll*(s: ZSocket, msg: varargs[string]) =
   ## Send msg as a multipart message
   let msglen = msg.len
   if msglen > 0:
@@ -282,7 +282,7 @@ proc send*(c: ZConnection, msg: string, flags: ZSendRecvOptions = NOFLAGS) =
   ## Sends a message over the connection.
   send(c.socket, msg, flags)
 
-proc sendAll*(c: ZConnection, msg: openArray[string]) =
+proc sendAll*(c: ZConnection, msg: varargs[string]) =
   ## Send msg as a multipart message over the connection
   sendAll(c.socket, msg)
 


### PR DESCRIPTION
* Add high-level proxy function (having to use ``nil`` for no capture socket is ugly)
* Added documentation on async procs that reference the currently open libzmq bug when using ZMQ_FD (you may not get the actual file descriptor)
* bump versions to v1.2.0
* Added errno code to ZmqError type to be able to handle different ``errno` code manually; for instance :
```nim
try:
   # Do something that raise a ZmqError
except ZmqError:
  let e = cast[ref ZmqError](getCurrentException())
  echo e.error # errno code
  if e.error == EAGAIN:
    discard
  else:
    raise e
```

On EAGAIN during receive (#5 ) : 
* Stopped raising exception on EAGAIN during ``msg_recv`` as this cause ``RCVTIMEO`` to raise an exception when it shouldn't
* Add tryReceive that returns a ``tuple[msgAvailable: bool, moreAvailable: bool, msg: string]`` for handling multipart message and EAGAIN (usually through RCVTIMEO) gracefully. => The ``receive`` API did not change signature so there's no breaking change (just EAGAIN on receive that do not raise an excpetion but instead return an empty string).

Some quality of life sutff : 
* Add ``sendAll``  to send multipart message in one call
* Add ``receiveAll`` to receive multipart message as a ``seq[string]``

@Araq The CI to deploy the doc gen is ready.
Just need a few last steps (that I don't have permission to do) on the repo to enable it : 
* create a branch ``gh-pages`` 
* enable github pages on branch ``gh-pages`` targeting ``docs/`` folder. 
* restart the ``docs`` actions in CI and it should be done.
