### PR TITLE
Fix AsyncZpoller using iterator in async context

### DIFF
--- a/zmq.nimble
+++ b/zmq.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "1.3.0"
+version       = "1.3.1"
 author        = "Andreas Rumpf"
 description   = "ZeroMQ wrapper"
 license       = "MIT"


### PR DESCRIPTION
* Having multiple connection on an async poller was causing wrong callback to be called because of the reliance of an iterators  
* Current existing tests only had one connection and therefore didn't catch the bug. => Current test has been updated for a pollAsync on multiple connection.