### PR TITLE
Clonkk patch 1

### DIFF
--- a/zmq.nimble
+++ b/zmq.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "1.5.0"
+version       = "1.5.1"
 author        = "Andreas Rumpf"
 description   = "ZeroMQ wrapper"
 license       = "MIT"

--- a/zmq.nimble
+++ b/zmq.nimble
@@ -6,7 +6,7 @@ description   = "ZeroMQ wrapper"
 license       = "MIT"
 
 # Dependencies
-requires "nim >= 1.4.0"
+requires "nim >= 2.0.0"
 
 task buildexamples, "Compile all examples":
   withDir "examples":


### PR DESCRIPTION
Since the change from ``=destroy[T](x: var T)`` to ``=destroy[T](x: T)`` it's not compatible with Nim pre-2.0