### PR TITLE
Devel

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The examples are commented to better understand how zmq works.
 
 ### Log EAGAIN errno
 
-Sometimes EAGAIN error happens in ZMQ context; typically this is a non-ctritical error that can be ignored. Nonetheless, if you desire to logg or display such error you can compile with the flag ``-d:zmqEAGAIN`` and EAGAIN error will be logged using ``std/logging`` or ``echo`` to stdout if no logger handler is defined.
+Sometimes EAGAIN error happens in ZMQ context; typically this is a non-ctritical error that can be ignored. Nonetheless, if you desire to log or display such error, it is possible to enable it using the ``enableLogEagain`` and disable it with ``disableLogEagain``.
 
 ### Setting default flag as DONTWAIT
 

--- a/README.md
+++ b/README.md
@@ -54,3 +54,7 @@ The examples are commented to better understand how zmq works.
 ### Log EAGAIN errno
 
 Sometimes EAGAIN error happens in ZMQ context; typically this is a non-ctritical error that can be ignored. Nonetheless, if you desire to logg or display such error you can compile with the flag ``-d:zmqEAGAIN`` and EAGAIN error will be logged using ``std/logging`` or ``echo`` to stdout if no logger handler is defined.
+
+### Setting default flag as DONTWAIT
+
+The default flag passed to send / receive is NOFLAGS. This can be overriden by defining ``-d:defaultFlagDontWait``

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ nimble install zmq
   close(responder)
 ```
 
-#### client 
+#### client
 
 ```nim
   import zmq
@@ -49,3 +49,8 @@ $ nimble install zmq
 For more examples demonstrating many functionalities and patterns that ZMQ offers, see the ``tests/`` and ``examples/`` folder.
 
 The examples are commented to better understand how zmq works.
+
+
+### Log EAGAIN errno
+
+Sometimes EAGAIN error happens in ZMQ context; typically this is a non-ctritical error that can be ignored. Nonetheless, if you desire to logg or display such error you can compile with the flag ``-d:zmqEAGAIN`` and EAGAIN error will be logged using ``std/logging`` or ``echo`` to stdout if no logger handler is defined.

--- a/tests/async_demo.nim
+++ b/tests/async_demo.nim
@@ -22,13 +22,18 @@ proc asyncpoll() =
       puller2,
       ZMQ_POLLIN,
       proc(x: ZSocket) =
-        let msg = x.receive()
-        inc(msgCount)
-        if msglist.contains(msg):
-          msglist.delete(0)
-          assert true
-        else:
-          assert false
+        let
+          # Avoid using indefinitly blocking proc in async context
+          res = x.waitForReceive(timeout=10)
+        if res.msgAvailable:
+          let
+            msg = res.msg
+          inc(msgCount)
+          if msglist.contains(msg):
+            msglist.delete(0)
+            assert true
+          else:
+            assert false
     )
     # assert message received are correct (should be even integer in string format)
     var msglist2 = @["0", "2", "4", "6", "8"]
@@ -37,13 +42,18 @@ proc asyncpoll() =
       puller,
       ZMQ_POLLIN,
       proc(x: ZSocket) =
-        let msg = x.receive()
-        inc(msgCount2)
-        if msglist2.contains(msg):
-          msglist2.delete(0)
-          assert true
-        else:
-          assert false
+        let
+          # Avoid using indefinitly blocking proc in async context
+          res = x.waitForReceive(timeout=10)
+        if res.msgAvailable:
+          let
+            msg = res.msg
+          inc(msgCount2)
+          if msglist2.contains(msg):
+            msglist2.delete(0)
+            assert true
+          else:
+            assert false
     )
 
     let

--- a/tests/tzmq.nim
+++ b/tests/tzmq.nim
@@ -219,13 +219,15 @@ proc asyncpoll() =
       puller2,
       ZMQ_POLLIN,
       proc(x: ZSocket) =
-        let msg = x.receive()
-        inc(msgCount)
-        if msglist.contains(msg):
-          msglist.delete(0)
-          check true
-        else:
-          check false
+        let res= x.tryReceive()
+        if res.msgAvailable:
+          let msg = res.msg
+          inc(msgCount)
+          if msglist.contains(msg):
+            msglist.delete(0)
+            check true
+          else:
+            check false
     )
     # Check message received are correct (should be even integer in string format)
     var msglist2 = @["0", "2", "4", "6", "8"]
@@ -234,13 +236,15 @@ proc asyncpoll() =
       puller,
       ZMQ_POLLIN,
       proc(x: ZSocket) =
-        let msg = x.receive()
-        inc(msgCount2)
-        if msglist2.contains(msg):
-          msglist2.delete(0)
-          check true
-        else:
-          check false
+        let res = x.tryReceive()
+        if res.msgAvailable:
+          let msg = res.msg
+          inc(msgCount2)
+          if msglist2.contains(msg):
+            msglist2.delete(0)
+            check true
+          else:
+            check false
     )
 
     let

--- a/zmq.nimble
+++ b/zmq.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "1.5.1"
+version       = "1.5.2"
 author        = "Andreas Rumpf"
 description   = "ZeroMQ wrapper"
 license       = "MIT"
@@ -18,4 +18,3 @@ task buildexamples, "Compile all examples":
 
 task gendoc, "Generate documentation":
   exec("nim doc --mm:orc --project --out:docs/ zmq.nim")
-

--- a/zmq/asynczmq.nim
+++ b/zmq/asynczmq.nim
@@ -53,42 +53,44 @@ proc register*(poller: var AsyncZPoller, conn: ZConnection, event: int, cb: Asyn
 
 proc register*(poller: var AsyncZPoller, item: ZPollItem, cb: AsyncZPollCB) =
   ## Register ZConnection.
-  ## The callback should ideally use non-blocking proc such ``waitForReceive`` or ``tryReceive`` or ``c.receive(DONTWAIT)``
+  ## The callback should use non-blocking proc ``waitForReceive`` with strictly positive timeout or ``tryReceive`` or ``c.receive(DONTWAIT)``
   poller.zpoll.items.add(item)
   poller.cb.add(cb)
 
 proc initZPoller*(poller: sink ZPoller, cb: AsyncZPollCB) : AsyncZPoller =
-  ## The callback should ideally use non-blocking proc such ``waitForReceive`` or ``tryReceive`` or ``c.receive(DONTWAIT)``
+  ## The callback should use non-blocking proc such ``waitForReceive`` or ``tryReceive`` or ``c.receive(DONTWAIT)``
   for p in poller.items:
     result.register(p, cb)
 
 proc initZPoller*(args: openArray[tuple[item: ZConnection, cb: AsyncZPollCB]], event: cshort): AsyncZPoller =
   ## Init a ZPoller with all items on the same event
-  ## The callback should ideally use non-blocking proc such ``waitForReceive`` or ``tryReceive`` or ``c.receive(DONTWAIT)``
+  ## The callback should use non-blocking proc ``waitForReceive`` with strictly positive timeout or ``tryReceive`` or ``c.receive(DONTWAIT)``
   for arg in args:
     result.register(arg.item, event, arg.cb)
 
 proc pollAsync*(poller: AsyncZPoller, timeout: int = 2) : Future[int] =
   ## Experimental API. Poll all the ZConnection and execute an async CB when ``event`` occurs.
+  ## The callback should use non-blocking proc ``waitForReceive`` with strictly positive timeout or ``tryReceive`` or ``c.receive(DONTWAIT)``
 
-  block zmqAsyncContext:
-    var timeout = max(2, timeout)
-    result = newFuture[int]("pollAsync")
-    var r = poller.zpoll.poll(timeout div 2)
-    # ZMQ can't have a timeout smaller than one
-    if r > 0:
-      for i in 0..<poller.len():
-        if events(poller.zpoll[i]):
-          let
-            sock = poller.zpoll[i].socket
-            localcb = poller.cb[i]
-          callSoon proc () = localcb(sock)
+  var timeout = max(2, timeout)
+  result = newFuture[int]("pollAsync")
+  var r = poller.zpoll.poll(timeout div 2)
+  # ZMQ can't have a timeout smaller than one
+  if r > 0:
+    for i in 0..<poller.len():
+      if events(poller.zpoll[i]):
+        let
+          sock = poller.zpoll[i].socket
+          localcb = poller.cb[i]
+          sock.setsockopt(RCVTIMEO, 1.cint)
 
-    if hasPendingOperations():
-      # poll vs drain ?
-      drain(timeout div 2)
+        callSoon proc () = localcb(sock)
 
-    result.complete(r)
+  if hasPendingOperations():
+    # poll vs drain ?
+    drain(timeout div 2)
+
+  result.complete(r)
 
 proc receiveAsync*(conn: ZConnection): Future[string] =
   ## Similar to `receive()`, but `receiveAsync()` allows other async tasks to run.

--- a/zmq/asynczmq.nim
+++ b/zmq/asynczmq.nim
@@ -82,8 +82,6 @@ proc pollAsync*(poller: AsyncZPoller, timeout: int = 2) : Future[int] =
         let
           sock = poller.zpoll[i].socket
           localcb = poller.cb[i]
-          sock.setsockopt(RCVTIMEO, 1.cint)
-
         callSoon proc () = localcb(sock)
 
   if hasPendingOperations():

--- a/zmq/asynczmq.nim
+++ b/zmq/asynczmq.nim
@@ -66,7 +66,7 @@ proc initZPoller*(args: openArray[tuple[item: ZConnection, cb: AsyncZPollCB]], e
 proc pollAsync*(poller: AsyncZPoller, timeout: int = 2) : Future[int] =
   ## Experimental API. Poll all the ZConnection and execute an async CB when ``event`` occurs.
   result = newFuture[int]("pollAsync")
-  var r = poller.zpoll.poll(timeout)
+  var r = poller.zpoll.poll(1)
   # ZMQ can't have a timeout smaller than one
   if r > 0:
     for i in 0..<poller.len():
@@ -78,7 +78,7 @@ proc pollAsync*(poller: AsyncZPoller, timeout: int = 2) : Future[int] =
 
   if hasPendingOperations():
     # poll vs drain ?
-    drain(timeout)
+    poll(timeout)
 
   result.complete(r)
 
@@ -158,4 +158,3 @@ proc sendAsync*(conn: ZConnection, msg: string, flags: ZSendRecvOptions = DONTWA
     # can send without blocking
     conn.send(msg, flags)
     fut.complete()
-

--- a/zmq/connections.nim
+++ b/zmq/connections.nim
@@ -32,13 +32,23 @@ proc zmqError*() {.noinline, noreturn.} =
   e.msg = &"Error: {e.error}. " & $strerror(e.error)
   raise e
 
+var shouldLogEagainError = false
+
+proc enableLogEagain*() =
+  ## Enable logging EAGAIN error in ZMQ calls
+  shouldLogEagainError = true
+
+proc disableLogEagain*() =
+  ## Disable logging EAGAIN error in ZMQ calls
+  shouldLogEagainError = false
+
 proc zmqErrorExceptEAGAIN() =
   var e: ref ZmqError
   new(e)
   e.error = errno()
   let errmsg = $strerror(e.error)
   if e.error == ZMQ_EAGAIN:
-    when defined(zmqEAGAIN):
+    if shouldLogEagainError:
       if logging.getHandlers().len() > 0:
         warn(errmsg)
       else:

--- a/zmq/connections.nim
+++ b/zmq/connections.nim
@@ -49,24 +49,11 @@ proc zmqErrorExceptEAGAIN() =
     e.msg = &"Error: {e.error}. " & errmsg
     raise e
 
-# var gDefaultFlag = NOFLAGS
-
-# proc setDontWait() =
-#   gDefaultFlag = DONTWAIT
-
-# proc setNoFlags() =
-#   gDefaultFlag = NOFLAGS
-
 template defaultFlag() : ZSendRecvOptions =
-  when declared(zmqAsyncContext):
-    static: echo "DONTWAIT"
+  when defined(defaultFlagDontWait):
     DONTWAIT
   else:
-    static: echo "NOFLAGS"
     NOFLAGS
-
-  # debugEcho $gDefaultFlag
-  # gDefaultFlag
 
 #[
 # Context related proc
@@ -160,7 +147,6 @@ proc getsockopt*[T: SomeOrdinal|string](c: ZConnection, option: ZSockOptions): T
   ## Careful, the ``sizeof`` of ``optval`` depends on the ``ZSockOptions`` passed.
   ## Check http://api.zeromq.org/4-2:zmq-setsockopt
   getsockopt[T](c.socket, option)
-
 
 #[
   Destructor


### PR DESCRIPTION
* Add API to log or echo EAGAIN error
* Add -d:defaultFlagDontWait to change the default flag to receive / send proc to DONTWAIT instead of NOFLAGS
* Add docstring about using non-blocking in asyncPoll context
  * Modified examples and test to use non-blocking function in asyncPoll 
  * This shouldn't change anything for asyncReceive / asyncSend